### PR TITLE
feat: Implement JSON import and export

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,7 +900,7 @@
       }
 
       // ========= Controls =========
-      function initControls() {
+      function updateProjectChips() {
         state.projects = Array.from(
           new Set(ACTIVITIES.map((a) => a.project)),
         ).sort();
@@ -918,6 +918,12 @@
           chips.appendChild(c);
         });
         state.selected = new Set(state.projects);
+      }
+
+      function initControls() {
+        updateProjectChips();
+
+        const chips = document.getElementById("projectChips");
         chips.addEventListener("change", (e) => {
           const cb = e.target.closest('input[type="checkbox"]');
           if (!cb) return;
@@ -940,6 +946,7 @@
           }
           render();
         });
+
         document.getElementById("startCond").value = "<";
         document.getElementById("startInput").value = "Nov 2025";
         document.getElementById("endCond").value = ">";
@@ -953,11 +960,7 @@
           document.getElementById("startInput").value = "Nov 2025";
           document.getElementById("endCond").value = ">";
           document.getElementById("endInput").value = "Mar 2026";
-          chips.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
-            cb.checked = true;
-            cb.parentElement.classList.add("active");
-          });
-          state.selected = new Set(state.projects);
+          updateProjectChips();
           applyRange();
           render();
         });
@@ -981,12 +984,16 @@
 
       // ========= Data Exchange =========
       function exportActivitiesAsJson() {
+        const now = new Date();
+        const timestamp = `${now.getFullYear()}${(now.getMonth() + 1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}-${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
+        const filename = `roadmap-activities-${timestamp}.json`;
+
         const dataStr = JSON.stringify(ACTIVITIES, null, 2);
         const dataBlob = new Blob([dataStr], {type: "application/json"});
         const url = URL.createObjectURL(dataBlob);
         const a = document.createElement("a");
         a.href = url;
-        a.download = "roadmap-activities.json";
+        a.download = filename;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -1004,8 +1011,8 @@
             if (Array.isArray(importedData)) {
               ACTIVITIES = importedData;
               saveActivities(); // Persist the new data to LocalStorage
-              // Re-initialize the entire application state
-              initControls(); 
+              // Re-initialize the project filters and render
+              updateProjectChips(); 
               render();
               alert("Successfully imported activities.");
             } else {

--- a/index.html
+++ b/index.html
@@ -559,6 +559,9 @@
         </div>
         <button id="applyBtn" class="btn primary">Apply</button>
         <button id="resetBtn" class="btn">Reset</button>
+        <button id="exportJsonBtn" class="btn">Export JSON</button>
+        <button id="importJsonBtn" class="btn">Import JSON</button>
+        <input type="file" id="json-importer" style="display: none;" accept=".json,application/json">
       </div>
       <div id="msg" class="notice"></div>
     </header>
@@ -958,9 +961,67 @@
           applyRange();
           render();
         });
+
+        // JSON Export
+        document.getElementById("exportJsonBtn").addEventListener("click", () => {
+          exportActivitiesAsJson();
+        });
+
+        // JSON Import
+        const fileImporter = document.getElementById("json-importer");
+        document.getElementById("importJsonBtn").addEventListener("click", () => {
+          fileImporter.click();
+        });
+        fileImporter.addEventListener("change", (e) => {
+          importActivitiesFromJson(e.target.files[0]);
+        });
+
         applyRange();
       }
 
+      // ========= Data Exchange =========
+      function exportActivitiesAsJson() {
+        const dataStr = JSON.stringify(ACTIVITIES, null, 2);
+        const dataBlob = new Blob([dataStr], {type: "application/json"});
+        const url = URL.createObjectURL(dataBlob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "roadmap-activities.json";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+
+      function importActivitiesFromJson(file) {
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          try {
+            const importedData = JSON.parse(e.target.result);
+            // Basic validation: check if it's an array
+            if (Array.isArray(importedData)) {
+              ACTIVITIES = importedData;
+              saveActivities(); // Persist the new data to LocalStorage
+              // Re-initialize the entire application state
+              initControls(); 
+              render();
+              alert("Successfully imported activities.");
+            } else {
+              alert("Import failed: JSON file is not a valid activity array.");
+            }
+          } catch (err) {
+            console.error("Error parsing imported JSON:", err);
+            alert("Import failed: The selected file is not valid JSON.");
+          }
+        };
+        reader.onerror = function() {
+          alert("Error reading file.");
+        };
+        reader.readAsText(file);
+      }
+      
       // ========= Range =========
       function applyRange() {
         const sCondRaw = document.getElementById("startCond").value;


### PR DESCRIPTION
This commit adds functionality to import and export the project activities as a JSON file.

- Adds "Import JSON" and "Export JSON" buttons to the UI.
- The export function serializes data and triggers a download with a timestamped filename.
- The import function uses a file reader, parses the JSON, and updates the application state.
- Imported data is persisted to LocalStorage, and the UI is re-rendered.
- Fixes a bug where event listeners were being added multiple times, causing duplicate actions.

Closes #2