### PR TITLE
fix(render): Handle empty state for timeline view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1231,6 +1231,12 @@
         const filtered = ACTIVITIES.filter((a) =>
           state.selected.has(a.project),
         );
+
+        if (filtered.length === 0) {
+          cardsLayer.innerHTML = `<div class="empty" style="text-align: center; padding: 40px; margin: 20px auto; width: 300px;">No activities to display</div>`;
+          return;
+        }
+
         const grouped = groupByHalfMonthUnified(
           filtered,
           segs,


### PR DESCRIPTION
This PR fixes the rendering of the timeline when no activities are present, preventing the 'No activities' message from appearing in merged month cards.

Closes #10